### PR TITLE
UI: Properly handle longer dry run error messages.

### DIFF
--- a/client/app/assets/less/redash/query.less
+++ b/client/app/assets/less/redash/query.less
@@ -713,3 +713,16 @@ nav .rg-bottom {
     }
   }
 }
+
+query-editor {
+  div>button {
+    height: 30px;
+  }
+
+  .dry_run {
+    height: 30px;
+    overflow: auto;
+  }
+}
+
+

--- a/redash/__init__.py
+++ b/redash/__init__.py
@@ -16,7 +16,7 @@ from .app import create_app  # noqa
 from .query_runner import import_query_runners
 from .destinations import import_destinations
 
-__version__ = '8.0.4'
+__version__ = '8.0.5'
 
 
 if os.environ.get("REMOTE_DEBUG"):


### PR DESCRIPTION
Instead of longer messages breaking buttons on the UI
limit the error box to 30pxs and fix the size of the
buttons. This will produce scrollbars, but there's
no easy way around that.
