### PR TITLE
Preview: Preview button not always working.

### DIFF
--- a/client/app/components/queries/schema-browser.html
+++ b/client/app/components/queries/schema-browser.html
@@ -21,7 +21,7 @@
         <i
                 class="fa fa-search table-preview"
                 ng-if="$ctrl.preview && table.preview"
-                ng-click="$ctrl.preview($event, table.name)"
+                ng-click="$ctrl.preview_table($event, table.name)"
                 aria-hidden="true">
         </i>
       </div>

--- a/client/app/components/queries/schema-browser.js
+++ b/client/app/components/queries/schema-browser.js
@@ -29,7 +29,7 @@ function SchemaBrowserCtrl($rootScope, $scope) {
     $event.stopPropagation();
   };
 
-  this.preview = ($event, tableName) => {
+  this.preview_table = ($event, tableName) => {
     $event.preventDefault();
     $event.stopPropagation();
 


### PR DESCRIPTION
Change the name of the preview function to avoid a
conflict with the variable that is set if preview is
available on the datasource.