### PR TITLE
Transactions: Commit the query result to get it's generated ID.

### DIFF
--- a/redash/models/__init__.py
+++ b/redash/models/__init__.py
@@ -315,6 +315,11 @@ class QueryResult(db.Model, BelongsToOrgMixin):
                            retrieved_at=retrieved_at,
                            data=data)
         db.session.add(query_result)
+        db.session.commit()  # Make sure the query result is committed and assigned an ID.
+
+        if query_result.id is None:
+            raise Exception("inserted query result id is null for query_hash:" + query_hash)
+
         logging.info("Inserted query (%s) data; id=%s", query_hash, query_result.id)
         # TODO: Investigate how big an impact this select-before-update makes.
         queries = Query.query.filter(


### PR DESCRIPTION
Commit the query result to retrieve it's generated ID.
This ID is later used to update all the queries with the same query hash.

## What type of PR is this? (check all applicable)
<!-- Please leave only what's applicable -->

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [ ] New Query Runner (Data Source)
- [ ] New Alert Destination
- [ ] Other

## Description

## Related Tickets & Documents

## Mobile & Desktop Screenshots/Recordings (if there are UI changes)
